### PR TITLE
Bump node-rmrf to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "rmrf": "1.0.0",
+    "rmrf": "1.0.1",
     "mkdirp": "~0.3.5",
     "glob": "~3.2.1",
     "tar.gz": "~0.1.1",


### PR DESCRIPTION
Fixes the issue where rmrf errored if the folder you gave it didn't exist.
