### PR TITLE
Add optionalDependencies to the strategy.

### DIFF
--- a/lib/npm/strategy.js
+++ b/lib/npm/strategy.js
@@ -27,7 +27,8 @@ function NpmStrategy(options) {
   var pkgjson = require(Path.join(this.cwd, 'package.json'));
   this.dependencies = pkgjson.dependencies;
   this.devDependencies = pkgjson.devDependencies;
-  this.allDependencies = _.extend({}, this.dependencies, this.devDependencies);
+  this.optionalDependencies = pkgjson.optionalDependencies || {};
+  this.allDependencies = _.extend({}, this.dependencies, this.devDependencies, this.optionalDependencies);
 
   // ensure that the relevant directory exists
   mkdirp.sync(this.nodeModulesPath);


### PR DESCRIPTION
This is a valid option and one I am using to create custom local modules that dont exist on npm but are packable by pack. This way, npm install and other features dont break, but pac that still do its thing.