### PR TITLE
use rimraf instead of rmrf and skip fs.existsSync test

### DIFF
--- a/lib/bower/strategy.js
+++ b/lib/bower/strategy.js
@@ -6,7 +6,7 @@ var mkdirp = require('mkdirp');
 var Path = require('path');
 var glob = require('glob');
 var async = require('async');
-var rmrf = require('rmrf');
+var rimraf = require('rimraf');
 var _ = require('underscore');
 
 var log = function () {
@@ -66,9 +66,7 @@ BowerStrategy.prototype._install = function (type, destPath, callback) {
 
     if (deps[name]) {
       // remove existing installed module
-      if (fs.existsSync(Path.join(destPath, name))) {
-        rmrf(Path.join(destPath, name));
-      }
+      rimraf.sync(Path.join(destPath, name));
 
       // extract the module into node_modules
       new tgz().extract(archive, destPath, function (err) {

--- a/lib/npm/strategy.js
+++ b/lib/npm/strategy.js
@@ -6,7 +6,7 @@ var mkdirp = require('mkdirp');
 var Path = require('path');
 var glob = require('glob');
 var async = require('async');
-var rmrf = require('rmrf');
+var rimraf = require('rimraf');
 var _ = require('underscore');
 
 var log = function () {
@@ -52,9 +52,7 @@ NpmStrategy.prototype._install = function (type, destPath, callback) {
 
     if (deps[name]) {
       // remove existing installed module
-      if (fs.existsSync(Path.join(destPath, name))) {
-        rmrf(Path.join(destPath, name));
-      }
+      rimraf.sync(Path.join(destPath, name));
 
       // extract the module into node_modules
       new tgz().extract(archive, destPath, function (err) {

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "rmrf": "1.0.1",
-    "mkdirp": "~0.3.5",
-    "glob": "~3.2.1",
-    "tar.gz": "~0.1.1",
     "async": "~0.2.9",
-    "underscore": "~1.4.4",
-    "commander": "~2.1.0"
+    "commander": "~2.1.0",
+    "glob": "~3.2.1",
+    "mkdirp": "~0.3.5",
+    "rimraf": "^2.3.2",
+    "tar.gz": "~0.1.1",
+    "underscore": "~1.4.4"
   },
   "devDependencies": {
     "fs-extra": "^0.8.1",

--- a/test/bower/strategy.js
+++ b/test/bower/strategy.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var should = require('chai').should();
 var _ = require('underscore');
 var async = require('async');
 var glob = require('glob');

--- a/test/npm/strategy.js
+++ b/test/npm/strategy.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var should = require('chai').should();
 var _ = require('underscore');
 var async = require('async');
 var glob = require('glob');


### PR DESCRIPTION
If symlink are present in the node_modules directory, pac install will fail. This PR fixes this